### PR TITLE
[MERGE] cutcorners now cannot take larger input than possible

### DIFF
--- a/src/Synthesizer/UI/Filters.fs
+++ b/src/Synthesizer/UI/Filters.fs
@@ -25,10 +25,10 @@ module Filter =
     let Repeater (nbEcho:int) (decay:float) (delay:float) (sampleRate:float) (dryData:List<float>) = 
         let rec RepeaterInner (nbEcho:int) (decay:float) (delay:float) (sampleRate:float) (wetData:List<float>) (dryData:List<float>) =   // This is also echo
             if nbEcho=0 then
-                Utility.Add [dryData; wetData]
+                Utility.AddMean [dryData; wetData]
             else
                 let silence = SoundData(frequency0 = 0, duration0 = (Seconds (delay*float nbEcho)), bpm0 = 114).Create(Silence)
-                let updatedWetData = Utility.Add [wetData; List.concat [silence ; ChangeAmplitude decay dryData]]
+                let updatedWetData = Utility.AddMean [wetData; List.concat [silence ; ChangeAmplitude decay dryData]]
                 RepeaterInner (nbEcho-1) decay delay sampleRate updatedWetData dryData
 
         RepeaterInner nbEcho decay delay sampleRate [] dryData

--- a/src/Synthesizer/Utilities/Utility.fs
+++ b/src/Synthesizer/Utilities/Utility.fs
@@ -10,7 +10,8 @@ module Utility =
     let CutEnd (sampleRate:float) time (data:List<float>) = 
         data[0 .. data.Length - int (sampleRate * time)-1] //need to add another time for the end
 
-    let CutCorners limit (data:List<float>) =
+    let CutCorners (limit0:int) (data:List<float>) =
+        let limit = if limit0>data.Length/2 then data.Length/2 else limit0
         let step = 1. / float limit
         let startVals = List.map2(fun x i -> x * step * i) data[..limit-1] [1. .. float limit]
         let endVals = List.map2(fun x i -> x * step * i) data[data.Length-limit..] [float limit .. -1. .. 1.]


### PR DESCRIPTION
Utility.CutCornes broke when it got an input larger than the length of the sound data it was meant to be applied on.
The input value is ow limited to half the length of the sound data (the maximum logical value)